### PR TITLE
Add links to http://geojsonlint.com and Repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 <img src="https://api.travis-ci.org/JasonSanford/geojsonlint.com.png">
 
-A simple Django app to validate your GeoJSON.
+A simple Django app to validate your GeoJSON. This app is available at http://geojsonlint.com but can run locally with minimal effort.
 
 ## Getting Started
 

--- a/geojsonlint/templates/index.html
+++ b/geojsonlint/templates/index.html
@@ -79,7 +79,7 @@
         </div>
     </div>
     <div class="container">
-        <p>Use this site to validate and view your GeoJSON. For details about GeoJSON, <a href="https://tools.ietf.org/html/rfc7946">read the spec</a>.</p>
+        <p>Use this site to validate and view your GeoJSON. For details about GeoJSON, <a href="https://tools.ietf.org/html/rfc7946">read the spec</a>. This site's source code can be found on <a href="https://github.com/JasonSanford/geojsonlint.com">Github</a> </p>
     </div>
     <div class="container">
         <div id="input-output" class="row">


### PR DESCRIPTION
It appears that the site is back online.  This adds the website URL to the README again (reverts https://github.com/JasonSanford/geojsonlint.com/commit/ba355cd7cbfc14447aa330480b7ecacbd31c00fb)

Given that there is enough confusion that https://github.com/ropensci/geojsonlint needs to state "THIS IS NOT THE SRC FOR geojsonlint.com" on their repo, a link is also added referencing this GitHub Repository on the wesbite.

Resolves #28 